### PR TITLE
Fix Div and DivExp holding a high gate on the CLK output when reset

### DIFF
--- a/src/Div.cpp
+++ b/src/Div.cpp
@@ -157,7 +157,7 @@ void Div::process(const ProcessArgs &args) {
 
   outputs[PHASE_OUTPUT].setVoltage(this->phaseDivider.phase);
   outputs[CLOCK_OUTPUT].setVoltage(
-    (this->gateMode ? this->phaseDivider.inResetState == false && this->phaseDivider.phase < 5.0 : this->pulseGenerator.process(args.sampleTime)) ? 10.f : 0.f
+    (this->gateMode ? !this->phaseDivider.inResetState && this->phaseDivider.phase < 5.0 : this->pulseGenerator.process(args.sampleTime)) ? 10.f : 0.f
   );
 
   if (rightExpander.module &&
@@ -394,7 +394,7 @@ void DivExp::process(const ProcessArgs &args) {
 
   outputs[PHASE_OUTPUT].setVoltage(this->phaseDivider.phase);
   outputs[CLOCK_OUTPUT].setVoltage(
-    (this->gateMode ? this->phaseDivider.inResetState == false && this->phaseDivider.phase < 5.0 : this->pulseGenerator.process(args.sampleTime)) ? 10.f : 0.f
+    (this->gateMode ? !this->phaseDivider.isInResetState && this->phaseDivider.phase < 5.0 : this->pulseGenerator.process(args.sampleTime)) ? 10.f : 0.f
   );
   resetWasHitForMessage = false;
   this->firstCycle = false;

--- a/src/Div.cpp
+++ b/src/Div.cpp
@@ -157,7 +157,7 @@ void Div::process(const ProcessArgs &args) {
 
   outputs[PHASE_OUTPUT].setVoltage(this->phaseDivider.phase);
   outputs[CLOCK_OUTPUT].setVoltage(
-    (this->gateMode ? this->phaseDivider.phase < 5.0 : this->pulseGenerator.process(args.sampleTime)) ? 10.f : 0.f
+    (this->gateMode ? this->phaseDivider.inResetState == false && this->phaseDivider.phase < 5.0 : this->pulseGenerator.process(args.sampleTime)) ? 10.f : 0.f
   );
 
   if (rightExpander.module &&
@@ -394,7 +394,7 @@ void DivExp::process(const ProcessArgs &args) {
 
   outputs[PHASE_OUTPUT].setVoltage(this->phaseDivider.phase);
   outputs[CLOCK_OUTPUT].setVoltage(
-    (this->gateMode ? this->phaseDivider.phase < 5.0 : this->pulseGenerator.process(args.sampleTime)) ? 10.f : 0.f
+    (this->gateMode ? this->phaseDivider.inResetState == false && this->phaseDivider.phase < 5.0 : this->pulseGenerator.process(args.sampleTime)) ? 10.f : 0.f
   );
   resetWasHitForMessage = false;
   this->firstCycle = false;

--- a/src/PhaseDivider.hpp
+++ b/src/PhaseDivider.hpp
@@ -9,12 +9,14 @@ struct PhaseDivider {
   float lastPhaseInDelta = 0.f;
   double phase = 0.0;
   double lastPhase = 0.0;
+  bool inResetState = true;
 
   void reset() {
     this->phase = 0.0;
     this->lastPhase = 0.0;
     this->lastPhaseIn = 0.f;
     this->lastPhaseInDelta = 0.f;
+    this->inResetState = true;
   }
 
   void requestRatio(float newRatio) {
@@ -64,6 +66,7 @@ struct PhaseDivider {
     } else {
       this->phase = newPhase;
     }
+    this->inResetState = ( this->inResetState ? phaseIn == this->lastPhaseIn : false );
     lastPhase = this->phase;
     lastPhaseIn = phaseIn;
     return slaveFlipped;

--- a/src/PhaseDivider.hpp
+++ b/src/PhaseDivider.hpp
@@ -9,14 +9,14 @@ struct PhaseDivider {
   float lastPhaseInDelta = 0.f;
   double phase = 0.0;
   double lastPhase = 0.0;
-  bool inResetState = true;
+  bool isInResetState = true;
 
   void reset() {
     this->phase = 0.0;
     this->lastPhase = 0.0;
     this->lastPhaseIn = 0.f;
     this->lastPhaseInDelta = 0.f;
-    this->inResetState = true;
+    this->isInResetState = true;
   }
 
   void requestRatio(float newRatio) {
@@ -66,7 +66,7 @@ struct PhaseDivider {
     } else {
       this->phase = newPhase;
     }
-    this->inResetState = ( this->inResetState ? phaseIn == this->lastPhaseIn : false );
+    this->isInResetState = this->isInResetState ? phaseIn == this->lastPhaseIn : false;
     lastPhase = this->phase;
     lastPhaseIn = phaseIn;
     return slaveFlipped;


### PR DESCRIPTION
This fixes an issue in the Div and DivExp modules where they would output a high gate on the clock (CLK) output after they are reset and the master clock module is not running, or the phase input was not changing. The fix waits for the phase input to change before the clock output of the Div module is allowed to output a high gate output.